### PR TITLE
Fix missaligned paths for llp_rrzk (formerly fpgaInfrastructure)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN useradd --shell /bin/bash -u $USER_ID -o -c "" build
 # Copy system config files
 COPY cfg_files/profile_d_ccache.sh /etc/profile.d/ccache.sh
 COPY cfg_files/profile_d_xilinx_docker_path.sh /etc/profile.d/xilinx_docker_path.sh
-COPY cfg_files/profile_d_fpgainfrastructure_paths.sh /etc/profile.d/fpgainfrastructure.sh
+COPY cfg_files/profile_d_llp_rrzk_paths.sh /etc/profile.d/llp_rrzk.sh
 # Add and apply configuration of ld
 COPY cfg_files/ld.so.conf /etc/
 RUN ldconfig

--- a/cfg_files/profile_d_fpgainfrastructure_paths.sh
+++ b/cfg_files/profile_d_fpgainfrastructure_paths.sh
@@ -1,3 +1,0 @@
-export PATH="/home/build/fpgainfrastructure/hw/build_ip:$PATH"
-export PATH="/home/build/fpgainfrastructure/hw/orka_hw_configurator:$PATH"
-export PATH="/home/build/fpgainfrastructure/hw/:$PATH"

--- a/cfg_files/profile_d_llp_rrzk_paths.sh
+++ b/cfg_files/profile_d_llp_rrzk_paths.sh
@@ -1,0 +1,3 @@
+export PATH="/opt/llp_rrzk/hw/build_ip:$PATH"
+export PATH="/opt/llp_rrzk/hw/orka_hw_configurator:$PATH"
+export PATH="/opt/llp_rrzk/hw/:$PATH"


### PR DESCRIPTION
`fpgaInfrastructure` was moved to `llp_rrzk`, but `PATH` was not updated accordingly.

`PATH` will now include the default install dir (`/opt/llp_rrzk`) instead.